### PR TITLE
Issue #76 - fixed typo - emergencyContacts

### DIFF
--- a/TwoWeeksReady.Common/FamilyPlans/FamilyPlan.cs
+++ b/TwoWeeksReady.Common/FamilyPlans/FamilyPlan.cs
@@ -21,7 +21,7 @@ namespace TwoWeeksReady.Common.FamilyPlans
     [JsonProperty("phoneNumber")]
     public string PhoneNumber { get; set; }
 
-    [JsonProperty("emergecyContacts")]
+    [JsonProperty("emergencyContacts")]
     public List<Contact> EmergencyContacts { get; set; } = new List<Contact>();
 
     [JsonProperty("routeLocations")]


### PR DESCRIPTION
Updated `emergecyContacts` to `emergencyContacts` in family plan. 

This should resolve Issue #76 