### PR TITLE
Issue 74 - Removing exposed json in family-plan/add-child

### DIFF
--- a/2wr-app/src/components/prepare/family-plans/editors/child-editor.vue
+++ b/2wr-app/src/components/prepare/family-plans/editors/child-editor.vue
@@ -53,7 +53,6 @@
         <v-btn text color="green" @click="save">Save</v-btn>
       </v-card-actions>
     </v-form>
-    <pre>{{ theChild }}</pre>
   </v-card>
 </template>
 

--- a/TwoWeeksReady.Common/FamilyPlans/FamilyPlan.cs
+++ b/TwoWeeksReady.Common/FamilyPlans/FamilyPlan.cs
@@ -21,7 +21,7 @@ namespace TwoWeeksReady.Common.FamilyPlans
     [JsonProperty("phoneNumber")]
     public string PhoneNumber { get; set; }
 
-    [JsonProperty("emergencyContacts")]
+    [JsonProperty("emergecyContacts")]
     public List<Contact> EmergencyContacts { get; set; } = new List<Contact>();
 
     [JsonProperty("routeLocations")]

--- a/TwoWeeksReady.Common/FamilyPlans/FamilyPlan.cs
+++ b/TwoWeeksReady.Common/FamilyPlans/FamilyPlan.cs
@@ -21,7 +21,7 @@ namespace TwoWeeksReady.Common.FamilyPlans
     [JsonProperty("phoneNumber")]
     public string PhoneNumber { get; set; }
 
-    [JsonProperty("emergecyContacts")]
+    [JsonProperty("emergencyContacts")]
     public List<Contact> EmergencyContacts { get; set; } = new List<Contact>();
 
     [JsonProperty("routeLocations")]


### PR DESCRIPTION
Removed line of vuejs that is displaying a json object at bottom of family-plan/add-child view